### PR TITLE
Refactor Any<T> and Opt classes; enhance tests

### DIFF
--- a/src/libanvl.Opt/Any.cs
+++ b/src/libanvl.Opt/Any.cs
@@ -57,7 +57,7 @@ public static class Any
 public struct Any<T> : IEquatable<Any<T>>, IEnumerable<T>
     where T : notnull
 {
-    private static readonly Any<T> none = new();
+    private static readonly Any<T> none = [];
 
     private Opt<T> _single;
     private Opt<List<T>> _many;

--- a/src/libanvl.Opt/AnyMap.cs
+++ b/src/libanvl.Opt/AnyMap.cs
@@ -34,16 +34,11 @@ public class AnyMap<K, V> : Dictionary<K, Any<V>>, IAnyRefMap<K, V>
         return ref value;
     }
 
-    bool IAnyRefMap<K, V>.TryGetValueRef(K key, ref Any<V> value)
+    ref Any<V> IAnyRefMap<K, V>.GetValueRef(K key, out bool found)
     {
-        ref Any<V> refValue = ref CollectionsMarshal.GetValueRefOrNullRef(this, key);
-        if (Unsafe.IsNullRef(ref refValue))
-        {
-            return false;
-        }
-
-        value = ref refValue;
-        return true;
+        ref Any<V> value = ref CollectionsMarshal.GetValueRefOrNullRef(this, key);
+        found = !Unsafe.IsNullRef(ref value);
+        return ref value;
     }
 
     void IAnyRefMap<K, V>.ForEachRef(IAnyRefMap<K, V>.RefAction action)

--- a/src/libanvl.Opt/IAnyRefMap.cs
+++ b/src/libanvl.Opt/IAnyRefMap.cs
@@ -41,12 +41,12 @@ public interface IAnyRefMap<K, V>
     ref Any<V> GetValueRef(K key);
 
     /// <summary>
-    /// Tries to get a reference to the value associated with the specified key.
+    /// Gets a reference to the value associated with the specified key.
     /// </summary>
     /// <param name="key">The key whose value to get.</param>
-    /// <param name="value">When this method returns, contains the reference to the value associated with the specified key, if the key is found; otherwise, the default value for the type of the value parameter. This parameter is passed uninitialized.</param>
-    /// <returns><see langword="true"/> if the map contains an element with the specified key; otherwise, <see langword="false"/>.</returns>
-    bool TryGetValueRef(K key, ref Any<V> value);
+    /// <param name="found">When this method returns, contains <see langword="true"/> if the key was found; otherwise, <see langword="false"/>.</param>
+    /// <returns>A reference to the value associated with the specified key, or a null ref if not found.</returns>
+    ref Any<V> GetValueRef(K key, out bool found);
 
     /// <summary>
     /// Performs the specified action on each key and reference to a value in the map.

--- a/src/libanvl.Opt/Opt.cs
+++ b/src/libanvl.Opt/Opt.cs
@@ -1,6 +1,7 @@
 ﻿using libanvl.Exceptions;
 using System.Collections;
 using System;
+using System.Runtime.Serialization;
 
 namespace libanvl;
 

--- a/test/libanvl.Opt.Test/AnyMapTests.cs
+++ b/test/libanvl.Opt.Test/AnyMapTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace libanvl.opt.test;
@@ -72,12 +73,48 @@ public class AnyMapTests
             { "key1", new Any<int>(1) },
             { "key2", new Any<int>(2) }
         };
+        
         var values = new List<int>();
         foreach (var p in ((IAnyRefMap<string, int>)map))
         {
             values.Add(p.Single.Unwrap());
         }
+
         Assert.Contains(1, values);
         Assert.Contains(2, values);
+    }
+
+    [Fact]
+    public void Indexer_ReturnsCopy()
+    {
+        AnyMap<string, int> map = new AnyMap<string, int>();
+        map["key1"] = 42;
+
+        Assert.True(map["key1"].IsSingle);
+
+        map["key1"].Add(34);
+
+        Assert.True(map["key1"].IsSingle);
+        Assert.Equal(42, map["key1"].Single.Unwrap());
+    }
+
+    [Fact]
+    public void GetValueRef_WithFoundFlag_ShouldReturnReferenceAndSetFoundFlag()
+    {
+        var map = new AnyMap<string, int> { { "key1", new Any<int>(42) } };
+        ref var value = ref ((IAnyRefMap<string, int>)map).GetValueRef("key1", out bool found);
+
+        Assert.True(found);
+        Assert.Equal(42, value.Single.Unwrap());
+    }
+
+    [Fact]
+    public void GetValueRef_WithFoundFlag_ShouldReturnNullRefAndSetFoundFlagToFalse()
+    {
+        var map = new AnyMap<string, int>();
+        ref var value = ref ((IAnyRefMap<string, int>)map).GetValueRef("key1", out bool found);
+
+        Assert.False(found);
+        Assert.True(Unsafe.IsNullRef(ref value));
     }
 }

--- a/test/libanvl.Opt.Test/OptTests.cs
+++ b/test/libanvl.Opt.Test/OptTests.cs
@@ -126,4 +126,146 @@ public class OptTests
         var opt = Opt<int>.None;
         Assert.Equal("None", opt.ToString());
     }
+
+    [Fact]
+    public void Match_InvokesSomeFunc_WhenIsSome()
+    {
+        var opt = Opt.Some(5);
+        bool someInvoked = false;
+        bool noneInvoked = false;
+
+        opt.Match(
+            some: _ => someInvoked = true,
+            none: () => noneInvoked = true
+        );
+
+        Assert.True(someInvoked);
+        Assert.False(noneInvoked);
+    }
+
+    [Fact]
+    public void Match_InvokesNoneFunc_WhenIsNone()
+    {
+        var opt = Opt<int>.None;
+        bool someInvoked = false;
+        bool noneInvoked = false;
+
+        opt.Match(
+            some: _ => someInvoked = true,
+            none: () => noneInvoked = true
+        );
+
+        Assert.False(someInvoked);
+        Assert.True(noneInvoked);
+    }
+
+    [Fact]
+    public void Match_InvokesSomeAction_WhenIsSome()
+    {
+        var opt = Opt.Some(5);
+        bool someInvoked = false;
+        bool noneInvoked = false;
+
+        opt.Match(
+            some: _ => { someInvoked = true; },
+            none: () => { noneInvoked = true; }
+        );
+
+        Assert.True(someInvoked);
+        Assert.False(noneInvoked);
+    }
+
+    [Fact]
+    public void Match_InvokesNoneAction_WhenIsNone()
+    {
+        var opt = Opt<int>.None;
+        bool someInvoked = false;
+        bool noneInvoked = false;
+
+        opt.Match(
+            some: _ => { someInvoked = true; },
+            none: () => { noneInvoked = true; }
+        );
+
+        Assert.False(someInvoked);
+        Assert.True(noneInvoked);
+    }
+    [Fact]
+    public void Equals_ReturnsTrue_WhenBothAreNone()
+    {
+        var opt1 = Opt<int>.None;
+        var opt2 = Opt<int>.None;
+        Assert.True(opt1.Equals(opt2));
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalse_WhenOneIsSomeAndOtherIsNone()
+    {
+        var opt1 = Opt.Some(5);
+        var opt2 = Opt<int>.None;
+        Assert.False(opt1.Equals(opt2));
+    }
+
+    [Fact]
+    public void Equals_ReturnsTrue_WhenBothAreSomeWithSameValue()
+    {
+        var opt1 = Opt.Some(5);
+        var opt2 = Opt.Some(5);
+        Assert.True(opt1.Equals(opt2));
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalse_WhenBothAreSomeWithDifferentValues()
+    {
+        var opt1 = Opt.Some(5);
+        var opt2 = Opt.Some(10);
+        Assert.False(opt1.Equals(opt2));
+    }
+
+    [Fact]
+    public void GetHashCode_ReturnsSameHashCode_WhenBothAreNone()
+    {
+        var opt1 = Opt<int>.None;
+        var opt2 = Opt<int>.None;
+        Assert.Equal(opt1.GetHashCode(), opt2.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_ReturnsSameHashCode_WhenBothAreSomeWithSameValue()
+    {
+        var opt1 = Opt.Some(5);
+        var opt2 = Opt.Some(5);
+        Assert.Equal(opt1.GetHashCode(), opt2.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_ReturnsDifferentHashCode_WhenBothAreSomeWithDifferentValues()
+    {
+        var opt1 = Opt.Some(5);
+        var opt2 = Opt.Some(10);
+        Assert.NotEqual(opt1.GetHashCode(), opt2.GetHashCode());
+    }
+    [Fact]
+    public void GetHashCode_ReturnsSameHashCode_ForSameValues()
+    {
+        var opt1 = Opt.Some(5);
+        var opt2 = Opt.Some(5);
+        Assert.Equal(opt1.GetHashCode(), opt2.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_ReturnsDifferentHashCode_ForDifferentValues()
+    {
+        var opt1 = Opt.Some(5);
+        var opt2 = Opt.Some(10);
+        Assert.NotEqual(opt1.GetHashCode(), opt2.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_ReturnsSameHashCode_ForNone()
+    {
+        var opt1 = Opt<int>.None;
+        var opt2 = Opt<int>.None;
+        Assert.Equal(opt1.GetHashCode(), opt2.GetHashCode());
+    }
 }


### PR DESCRIPTION
Refactor Any<T> and Opt classes; enhance tests

- Update `IAnyRefMap<K, V>` to change `TryGetValueRef` to `GetValueRef`, returning a reference and a found flag.
- Modify `AnyMap<K, V>` to align with the new interface method.
- Add new tests in `AnyExtensionsTests` for aggregate functionality and transformations on `Any<int>`.
- Enhance `AnyTests` with equality checks for `Any<T>` in various states.
- Introduce tests for the `Match` method and equality in the `Opt` class.
- Improve `AnyMapTests` to verify indexer behavior and the new `GetValueRef` method.