### PR TITLE
Fix nullable bugs in Select and From

### DIFF
--- a/test/libanvl.Opt.Test/OptTests.cs
+++ b/test/libanvl.Opt.Test/OptTests.cs
@@ -268,4 +268,78 @@ public class OptTests
         var opt2 = Opt<int>.None;
         Assert.Equal(opt1.GetHashCode(), opt2.GetHashCode());
     }
+
+    [Fact]
+    public void Select_ReturnsTransformedOption_WhenSome()
+    {
+        var opt = Opt.Some(5);
+        var result = opt.Select(x => x * 2);
+        Assert.True(result.IsSome);
+        Assert.Equal(10, result.Unwrap());
+    }
+
+    [Fact]
+    public void Select_ReturnsNone_WhenTransformedValueIsNull()
+    {
+        var opt = Opt.Some("Hello");
+        var result = opt.Select<string>(x => null);
+        Assert.True(result.IsNone);
+    }
+
+    [Fact]
+    public void Select_ReturnsNone_WhenTransformedValueIsNullValueType()
+    {
+        Opt<int> opt = 5;
+        var result = opt.Select<int>(_ => null);
+        Assert.True(result.IsNone);
+    }
+
+    [Fact]
+    public void Select_ReturnsNone_WhenNone()
+    {
+        var opt = Opt<int>.None;
+        var result = opt.Select(x => x * 2);
+        Assert.True(result.IsNone);
+    }
+
+    [Fact]
+    public void Where_ReturnsSome_WhenPredicateIsTrue()
+    {
+        var opt = Opt.Some(5);
+        var result = opt.Where(x => x > 3);
+        Assert.True(result.IsSome);
+    }
+
+    [Fact]
+    public void Where_ReturnsNone_WhenPredicateIsFalse()
+    {
+        var opt = Opt.Some(5);
+        var result = opt.Where(x => x < 3);
+        Assert.True(result.IsNone);
+    }
+
+    [Fact]
+    public void Where_ReturnsNone_WhenOptionIsNone()
+    {
+        var opt = Opt<int>.None;
+        var result = opt.Where(x => x > 3);
+        Assert.True(result.IsNone);
+    }
+
+    [Fact]
+    public void Cast_ReturnsSome_WhenCastIsValid()
+    {
+        var opt = Opt.Some((object)5);
+        var result = opt.Cast<int>();
+        Assert.True(result.IsSome);
+        Assert.Equal(5, result.Unwrap());
+    }
+
+    [Fact]
+    public void Cast_ReturnsNone_WhenCastIsInvalid()
+    {
+        var opt = Opt.Some((object)"string");
+        var result = opt.Cast<int>();
+        Assert.True(result.IsNone);
+    }
 }


### PR DESCRIPTION
Updated the `Opt` class in `Opt.cs` to include XML documentation for the `From` method, which now supports both nullable value types and non-nullable reference types. Converted `Zip` and `Flatten` methods to extension methods. Changed the constructor of `Opt<T>` to internal and modified the `Select` method to accept functions returning nullable types. Added a new `Where` method for filtering options based on predicates.

In `OptTests.cs`, added unit tests for the `Select` and `Where` methods, covering value transformations, null handling, and behavior when the option is `None`. Included additional tests for casting options to validate correct and incorrect casts.